### PR TITLE
build fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "portfolio",
   "version": "2.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20.x"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/utils/fetchBlogs.ts
+++ b/utils/fetchBlogs.ts
@@ -1,9 +1,64 @@
 import { BlogPost } from "../typings";
 
+const HASHNODE_GQL = "https://gql.hashnode.com/";
+const BLOG_HOST = "blog.rdshinde.com";
+
+const query = `
+  query GetPosts($host: String!, $first: Int!) {
+    publication(host: $host) {
+      title
+      url
+      posts(first: $first) {
+        edges {
+          node {
+            id
+            title
+            slug
+            brief
+            publishedAt
+            readTimeInMinutes
+            coverImage {
+              url
+            }
+            tags {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const fetchBlogs = async (): Promise<BlogPost[]> => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/getBlogs`
-  );
-  const { blogs } = await res.json();
-  return blogs;
+  try {
+    const response = await fetch(HASHNODE_GQL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query,
+        variables: { host: BLOG_HOST, first: 10 },
+      }),
+    });
+
+    const json = await response.json();
+    const edges = json?.data?.publication?.posts?.edges ?? [];
+    const publicationUrl =
+      json?.data?.publication?.url ?? `https://${BLOG_HOST}`;
+
+    return edges.map((edge: any) => ({
+      id: edge.node.id,
+      title: edge.node.title,
+      slug: edge.node.slug,
+      brief: edge.node.brief,
+      publishedAt: edge.node.publishedAt,
+      readTimeInMinutes: edge.node.readTimeInMinutes ?? 0,
+      coverImage: edge.node.coverImage?.url ?? "",
+      tags: (edge.node.tags ?? []).map((t: any) => t.name),
+      url: `${publicationUrl}/${edge.node.slug}`,
+    }));
+  } catch (error) {
+    console.error("Failed to fetch blogs from Hashnode:", error);
+    return [];
+  }
 };

--- a/utils/fetchExperience.ts
+++ b/utils/fetchExperience.ts
@@ -1,10 +1,10 @@
+import { groq } from "next-sanity";
+import { sanityClient } from "../sanity";
 import { Experience } from "../typings";
 
+const query = groq`*[_type == "experience"]{ ..., technologies[]-> }`;
+
 export const fetchExperience = async (): Promise<Experience[]> => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/getExperience`
-  );
-  const { experience } = await res.json();
-  //   console.log(experience);
+  const experience: Experience[] = await sanityClient.fetch(query);
   return experience;
 };

--- a/utils/fetchPageInfo.ts
+++ b/utils/fetchPageInfo.ts
@@ -1,10 +1,10 @@
+import { groq } from "next-sanity";
+import { sanityClient } from "../sanity";
 import { PageInfo } from "../typings";
 
+const query = groq`*[_type == "pageInfo"][0]`;
+
 export const fetchPageInfo = async (): Promise<PageInfo> => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/getPageInfo`
-  );
-  const { pageInfo } = await res.json();
-  // console.log(pageInfo);
+  const pageInfo: PageInfo = await sanityClient.fetch(query);
   return pageInfo;
 };

--- a/utils/fetchProjects.ts
+++ b/utils/fetchProjects.ts
@@ -1,10 +1,10 @@
+import { groq } from "next-sanity";
+import { sanityClient } from "../sanity";
 import { Project } from "../typings";
 
+const query = groq`*[_type == "project"]{ ..., technologies[]-> }`;
+
 export const fetchProjects = async (): Promise<Project[]> => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}/api/getProjects`
-  );
-  const { projects } = await res.json();
-//   console.log(projects);
+  const projects: Project[] = await sanityClient.fetch(query);
   return projects;
 };

--- a/utils/fetchSkills.ts
+++ b/utils/fetchSkills.ts
@@ -1,9 +1,11 @@
+import { groq } from "next-sanity";
+import { sanityClient } from "../sanity";
 import { Skills } from "../typings";
 
+const query = groq`*[_type == "skill"]`;
+
 export const fetchSkills = async (): Promise<Skills[]> => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/getSkills`);
-  const { skills } = await res.json();
-//   console.log(skills);
+  const skills: Skills[] = await sanityClient.fetch(query);
   return skills;
 };
 

--- a/utils/fetchSocials.ts
+++ b/utils/fetchSocials.ts
@@ -1,8 +1,10 @@
+import { groq } from "next-sanity";
+import { sanityClient } from "../sanity";
 import { Social } from "../typings";
 
+const query = groq`*[_type == "social"]`;
+
 export const fetchSocials = async (): Promise<Social[]> => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/getSocials`);
-  const  {socials}  = await res.json();
-  //   console.log(socials);
+  const socials: Social[] = await sanityClient.fetch(query);
   return socials;
 };


### PR DESCRIPTION
This pull request refactors the data fetching utilities to directly query external data sources (Sanity and Hashnode) instead of routing through internal API endpoints. This change streamlines data retrieval, reduces unnecessary network hops, and improves maintainability. Additionally, it updates the Node.js engine requirement in `package.json`.

**Refactoring data fetching to use external sources directly:**

* Updated `fetchExperience`, `fetchPageInfo`, `fetchProjects`, `fetchSkills`, and `fetchSocials` to use GROQ queries with the Sanity client, removing reliance on internal API endpoints and simplifying the code. [[1]](diffhunk://#diff-9db6d8985035ec110bc9b3c9ce99fda47e5bff0a3d165a89a78a69405c648bf6R1-R8) [[2]](diffhunk://#diff-4e5c7ac2e5b2137dc60df2c65877de561a4184b88687482b8ca0a1b9f5fb2316R1-R8) [[3]](diffhunk://#diff-84e8af411edfdba552d3bfad72fdc70e1436a15e530487019c3d192a48639358R1-R8) [[4]](diffhunk://#diff-89b24159901f5c9e75e662d9c7685a56b77a4023aa85e8e41a7f820117905d4aR1-R8) [[5]](diffhunk://#diff-3077d4615df14d8affd29358aa5bf6166d0f4d83fed1582192c2a67c57a81056R1-R8)
* Refactored `fetchBlogs` to fetch blog posts directly from Hashnode's GraphQL API, replacing the previous approach of calling an internal API route.

**Project configuration update:**

* Added a Node.js engine requirement (`>=20.x`) in `package.json` to ensure compatibility with the project dependencies and codebase.